### PR TITLE
Fixed image margin causing length of page to grow

### DIFF
--- a/block/profile/style.css
+++ b/block/profile/style.css
@@ -22,6 +22,7 @@
 	background-size: cover;
 	background-position: center;
 	width: 60%;
+	overflow: hidden;
 }
 .wp-block-organic-profile-block .organic-profile-image img {
 	opacity: 0;


### PR DESCRIPTION
When the image was hidden with the margin, the body of my page would grow to make space for the image. Adding the overflow tag to the parent element allows the browser to ignore the space the image takes up outside of the parents element.